### PR TITLE
Fixed dynamic web content integration

### DIFF
--- a/mautic.php
+++ b/mautic.php
@@ -103,13 +103,17 @@ class MauticPlugin extends Plugin
         }
 
         foreach ($matches[0] as $key => $embed) {
-            parse_str(trim($matches[3][$key]), $args);
+            parse_str(trim(str_replace(" ", "&", $matches[3][$key])), $args);
 
-            $search = trim($matches[0][$key]);
-            $slot = trim($args['slot'], '"');
+            if (array_key_exists('slot', $args))
+                $slot = trim($args['slot'], '"');
+            else
+                $slot = '';
+
             $defaultContent = trim($matches[5][$key]);
+            $search = trim($matches[0][$key]);
 
-            $replace = '<div class="mautic-slot" data-slot-name="' . $slot . '">' . $defaultContent . '</div>';
+            $replace = '<div data-slot="dwc" data-param-slot-name="' . $slot . '">' . $defaultContent . '</div>';
 
             $content = str_replace($search, $replace, $content);
         }


### PR DESCRIPTION
* There was a bug in extracting the value for the 'slot' argument: Instead of
  extracting key/value pairs from the argument string, only the first parameter
  was extracted as key, with everything after the first '=' as value. This
  commit fixes this issue by replacing all spaces by '&' before calling
  'parse_str' on the parameter string

* Although the only parameter which is used is 'slot', there was no check
  whether the parameter has been set. Due to the above bug, the 'slot' parameter  was not extracted as such, resulting in an index error when looking up the  parameter in the array. This commit adds such a check, and inserts an empty  string if the 'slot' parameter is not set (and the value of the 'slot' parameter otherwise)

* The generated HTML is not compatible with recent versions of Mautic. This
  commit fixes that issue and makes it compatible to the currently stable
  version of Mautic (4.2.0)