### PR TITLE
Added support for legacy shortcode parameter interface

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 The MIT License (MIT)
 
 Copyright (c) 2014 Grav
-Copyright (c) 2022 Christian Krieg <christian@drkrieg.at>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/mautic.php
+++ b/mautic.php
@@ -116,7 +116,15 @@ class MauticPlugin extends Plugin
             $replace = '';
             $defaultContent = trim($matches[5][$key]);
 
-            # Extract parameters from shortcode
+            # Supporting legacy releases
+            if (array_key_exists('slot', $args))
+                $id = trim($args['slot'], '"');
+            if (array_key_exists('item', $args))
+                $id = trim($args['item'], '"');
+
+            # Extract parameters from shortcode; If both legacy and current
+            # parameters are given, current parameter has precedence and
+            # overrides a possible legacy parameter 
             if (array_key_exists('type', $args))
                 $type = trim($args['type'], '"');
             if (array_key_exists('id', $args))


### PR DESCRIPTION
* The unified interface can cause pages to break in case they use the legacy
shortcode parameter interface. Although chances are very low that this happens  (releases implementing the legacy interface are max. 2 days in the wild), I  implemented functionality that considers both the legacy and the current interface, making this change backwards-compatible.