### PR TITLE
Simplified shortcode interface for assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.5.1
+## 05/04/2022
+
+1. [](#improved)
+    * Simplifying shortcode interface for assets
+
 # v1.5.0
 ## 04/25/2022
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ available content types, as well as their associated IDs:
 | `form`    | The ID of the form (from Mautic "Components/Forms" overview table)                                        |
 | `content` | The DWC slot name (from Mautic "Components/Dynamic Content" element in edit mode as "Requested slot name")|
 | `focus`   | The ID of the focus item (from Mautic "Channels/Focus Items" overview table)                              |
-| `asset`   | The ID of the asset. Additionally, the asset's *alias* is needed, provided via the `asset` parameter      |
+| `asset`   | The ID of the asset. Additionally, the asset's *alias* is needed, appended to the ID by a colon (`:`)     |
 
 The general syntax is:
 
@@ -174,25 +174,35 @@ assets downloadable via direct links, we add the following shortcode into the
 content of a Grav page:
 
 ```
-[mautic type="asset" id="<ID>" alias="<ALIAS>"]
+[mautic type="asset" id="<ID>:<ALIAS>"]
   Link text
 [/mautic]
 ```
 
-The shortcode to insert asset links expects three parameters: Besides the usual
-`type` and `id` parameter, we also need to provide the *alias* of the asset.
-Both the ID and the alias can be found in the asset's details in Mautic. The
-text between the opening and closing shortcode tags is the text of the link that
-is generated to download the asset.
+The shortcode to insert asset links expects two parameters; Besides the usual
+`type` parameter, for the `id` parameter, we also need to provide the *alias* of
+the asset, joined with the asset's ID by a colon (`:`).  Both the ID and the
+alias can be found in the asset's details in Mautic. The text between the
+opening and closing shortcode tags is the text of the link that is generated to
+download the asset.
 
 The following example shows a shortcode that generates a link for donwloading a
 logo:
 
 ```
-[mautic type="asset" id="1" alias="logopng"]
+[mautic type="asset" id="1:logopdf"]
   Download our logo
 [/mautic]
 ```
+
+> :warning: **WARNING:** A separate `alias` parameter is still supported, but
+> deprecated since 1.6.0
+>
+> ```
+> [mautic type="asset" id="1" alias="logopng"]
+>   Download our logo
+> [/mautic]
+> ```
 
 The above example converts into the following HTML:
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ logo:
 [/mautic]
 ```
 
+The above example converts into the following HTML:
+
+```
+<a href="https://mautic.loc/asset/1:logopng">Download our logo</a>
+```
+
 > :warning: **WARNING:** A separate `alias` parameter is still supported, but
 > deprecated since 1.6.0
 >
@@ -203,9 +209,3 @@ logo:
 >   Download our logo
 > [/mautic]
 > ```
-
-The above example converts into the following HTML:
-
-```
-<a href="https://mautic.loc/asset/1:logopng">Download our logo</a>
-```

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The above example converts into the following HTML:
 ```
 
 > :warning: **WARNING:** A separate `alias` parameter is still supported, but
-> deprecated since 1.6.0
+> deprecated since 1.5.1
 >
 > ```
 > [mautic type="asset" id="1" alias="logopng"]

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Mautic
-version: 1.5.0
+version: 1.5.1
 description: "Mautic - Grav plugin integrates [Mautic](https://mautic.org) tracking, forms, dynamic web content, focus items, and assets into Grav CMS."
 icon: pie-chart
 author:

--- a/mautic.php
+++ b/mautic.php
@@ -117,7 +117,7 @@ class MauticPlugin extends Plugin
             $replace = '';
             $defaultContent = trim($matches[5][$key]);
 
-            # Supporting legacy releases
+            # Supporting legacy releases (for backwards compatibility to  1.3.2
             if (array_key_exists('slot', $args))
                 $id = trim($args['slot'], '"');
             if (array_key_exists('item', $args))
@@ -130,8 +130,12 @@ class MauticPlugin extends Plugin
                 $type = trim($args['type'], '"');
             if (array_key_exists('id', $args))
                 $id = trim($args['id'], '"');
-            if (array_key_exists('alias', $args))
+
+            # Support backwards compatibility to 1.5.0
+            if (array_key_exists('alias', $args)) {
                 $alias = trim($args['alias'], '"');
+                $id = $id . ':' . $alias;
+            }
 
             # Handle forms
             if ($type == "form")
@@ -167,8 +171,6 @@ class MauticPlugin extends Plugin
                         . $mauticBaseUrl
                         . '/asset/'
                         . $id
-                        . ':'
-                        . $alias
                         . '">'
                         . $defaultContent
                         . '</a>';


### PR DESCRIPTION
* Removed the `alias` parameter again to conform to unified shortcode interface
* Instead, the user has to join ID and alias manually with a colon (`:`)
